### PR TITLE
[audiopolicy] No longer make re-assigning legacy audio groups fatal. …

### DIFF
--- a/services/audiopolicy/engine/common/src/EngineBase.cpp
+++ b/services/audiopolicy/engine/common/src/EngineBase.cpp
@@ -206,9 +206,9 @@ engineConfig::ParsingResult EngineBase::loadAudioPolicyEngineConfig()
             }
             if (group.stream != AUDIO_STREAM_DEFAULT) {
                 // A legacy stream can be assigned once to a volume group
-                LOG_ALWAYS_FATAL_IF(checkStreamForGroups(group.stream, mVolumeGroups),
-                                    "stream %s already assigned to a volume group, "
-                                    "review the configuration", toString(group.stream).c_str());
+                if(checkStreamForGroups(group.stream, mVolumeGroups)) {
+                    ALOGE("stream %s already assigned to a volume group, review the configuration", toString(group.stream).c_str());
+                }
                 volumeGroup->addSupportedStream(group.stream);
             }
             addSupportedAttributesToGroup(group, volumeGroup, strategy);


### PR DESCRIPTION
…Mi9 declares AUDIO_STREAM_PATCH and AUDIO_STREAM_REROUTING which is defined by framework too

Change-Id: I794fe22d63a8af705be4f5f09b9879ecaab3eae5