### PR TITLE
libmedia: fix prebuilt camera hal's

### DIFF
--- a/media/libmedia/include/media/mediaplayer.h
+++ b/media/libmedia/include/media/mediaplayer.h
@@ -207,7 +207,8 @@ class MediaPlayer : public BnMediaPlayerClient,
                     public virtual IMediaDeathNotifier
 {
 public:
-    MediaPlayer(const std::string opPackageName = "");
+    MediaPlayer();
+    MediaPlayer(const std::string opPackageName);
     ~MediaPlayer();
             void            died();
             void            disconnect();

--- a/media/libmedia/mediaplayer.cpp
+++ b/media/libmedia/mediaplayer.cpp
@@ -41,6 +41,10 @@ namespace android {
 
 using media::VolumeShaper;
 
+MediaPlayer::MediaPlayer() : MediaPlayer("" /*opPackageName*/)
+{
+}
+
 MediaPlayer::MediaPlayer(const std::string opPackageName) : mOpPackageName(opPackageName)
 {
     ALOGV("constructor");


### PR DESCRIPTION
 * package name argument got added to MediaPlayer in fd90fdfe2a611ae824a32e236da288b1fdfd445d, which
   broke most prebuilt libcameraservice as they were built before
   this commit was merged

 * although a shim for this exists, it doesn't work well and
   crashes cameraservice whenever MediaPlayer() is called, seemingly
   due to a stack corruption

Change-Id: I1f8e112b1ab9cc96cb877dbee14767c28a377ab1